### PR TITLE
Setting: set DB schema

### DIFF
--- a/src/models/Keyword.js
+++ b/src/models/Keyword.js
@@ -1,0 +1,23 @@
+const mongoose = require("mongoose");
+
+const { Schema } = mongoose;
+
+const keywordSchema = new mongoose.Schema({
+  text: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  videoIds: {
+    type: [
+      {
+        type: Schema.Types.ObjectId,
+        ref: "Video",
+      },
+    ],
+    default: [],
+    required: true,
+  },
+});
+
+module.exports = mongoose.model("Keyword", keywordSchema);

--- a/src/models/OriginalKeyword.js
+++ b/src/models/OriginalKeyword.js
@@ -1,0 +1,10 @@
+const mongoose = require("mongoose");
+
+const originalKeywordSchema = new mongoose.Schema({
+  text: {
+    type: String,
+    unique: true,
+  },
+});
+
+module.exports = mongoose.model("OriginalKeyword", originalKeywordSchema);

--- a/src/models/Query.js
+++ b/src/models/Query.js
@@ -1,0 +1,16 @@
+const mongoose = require("mongoose");
+
+const querySchema = new mongoose.Schema({
+  text: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  count: {
+    type: Number,
+    default: 0,
+    required: true,
+  },
+});
+
+module.exports = mongoose.model("Query", querySchema);

--- a/src/models/Video.js
+++ b/src/models/Video.js
@@ -1,0 +1,37 @@
+const mongoose = require("mongoose");
+
+const videoSchema = new mongoose.Schema({
+  youtubeVideoId: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    required: true,
+  },
+  transcript: {
+    type: String,
+    required: true,
+  },
+  thumbnailURL: {
+    type: String,
+    required: true,
+  },
+  tag: {
+    type: String,
+    required: true,
+  },
+});
+
+videoSchema.pre("validate", function (next) {
+  this.transcript = this.transcript || " ";
+  this.tag = this.tag || " ";
+  next();
+});
+
+module.exports = mongoose.model("Video", videoSchema);


### PR DESCRIPTION
### [[BE] DB schema 세팅](https://www.notion.so/seongjunhong/BE-DB-schema-a71f1681e8394dc6ad5d47de72f6dbfa?pvs=4)

### description

- Mongoose를 이용하여 MongoDB 스키마 설정
- Video, Query, OriginalKeyword, Keyword 스키마 생성
- Video 스키마에서 유효성 검사전에 transcript, tag필드의 값이 없다면 " "을 넣어주었습니다.
- MongoDB Compass 에서 위의 collection들이 생성되는 거 확인 했습니다.


### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.
