### PR TITLE
Feat: add GET API: /videos/:video_id fetch video data

### DIFF
--- a/src/controllers/videos.controller.js
+++ b/src/controllers/videos.controller.js
@@ -1,10 +1,10 @@
 const Video = require("../models/Video");
 
 exports.fetchVideo = async function (req, res, next) {
-  const videoId = req.params.video_id;
+  const youtubeVideoId = req.params.video_id;
 
   try {
-    const video = await Video.findById(videoId);
+    const video = await Video.findOne({ youtubeVideoId });
 
     res.status(200).send({ result: "ok", video });
   } catch (error) {

--- a/src/controllers/videos.controller.js
+++ b/src/controllers/videos.controller.js
@@ -1,0 +1,18 @@
+const Video = require("../models/Video");
+
+exports.fetchVideo = async function (req, res, next) {
+  const videoId = req.params.video_id;
+
+  try {
+    const video = await Video.findById(videoId);
+
+    res.status(200).send({ result: "ok", video });
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({
+      result: "ng",
+      errorMessage:
+        "Hmm...something seems to have gone wrong. Maybe try me again in a little bit.",
+    });
+  }
+};

--- a/src/loaders/routers.js
+++ b/src/loaders/routers.js
@@ -1,11 +1,13 @@
 const indexRouter = require("../routes/index");
 const keywordsRouter = require("../routes/keywords");
 const autoCompletionsRouter = require("../routes/autoCompletions");
+const videosRouter = require("../routes/videos");
 
 async function routerLoader(app) {
   app.use("/", indexRouter);
   app.use("/keywords", keywordsRouter);
   app.use("/auto-completions", autoCompletionsRouter);
+  app.use("/videos", videosRouter);
 }
 
 module.exports = routerLoader;

--- a/src/routes/videos.js
+++ b/src/routes/videos.js
@@ -1,9 +1,9 @@
 const express = require("express");
 
-const videoController = require("../controllers/keywords.controller");
+const videosController = require("../controllers/videos.controller");
 
 const router = express.Router();
 
-router.post("/", videoController.searchVideos);
+router.get("/:video_id", videosController.fetchVideo);
 
 module.exports = router;

--- a/src/utils/calculateRank.js
+++ b/src/utils/calculateRank.js
@@ -58,8 +58,8 @@ async function calculateRank(query) {
         const denominator =
           termFrequency +
           K1 * (1 - B + B * (videoKeywords.length / averageDocumentLength));
-        scores[video._id] =
-          (scores[video._id] || 0) +
+        scores[video.youtubeVideoId] =
+          (scores[video.youtubeVideoId] || 0) +
           inverseDocumentFrequency * (numerator / denominator);
       });
     }


### PR DESCRIPTION
### [[BE] 단일 비디오 데이터 가져오기 GET API: /videos/:video_id](https://www.notion.so/seongjunhong/BE-GET-API-videos-video_id-1b7779112ad54c8ca142b2001b0796d6?pvs=4)

### description

- DataBase의 Video모델에서 video_id에 해당하는 video의 정보를 가져옵니다.
- 클라이언트 VideoList 컴포넌트에서 호출되어 사용할 예정입니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.
