### PR TITLE
Refactor: mongoose queries optimization using lean and handle empty userInput

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     semi: "warn",
     "no-underscore-dangle": 0,
     "func-names": "off",
+    "consistent-return": "off",
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,6 @@ module.exports = {
     semi: "warn",
     "no-underscore-dangle": 0,
     "func-names": "off",
-    "consistent-return": "off",
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
   },

--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -9,7 +9,9 @@ exports.getAutoCompletions = async function (req, res, next) {
     const matchingHistories = await Query.find(
       { text: { $regex: `^${userInput}`, $options: "i" } },
       {},
-    ).sort({ count: -1 });
+    )
+      .lean()
+      .sort({ count: -1 });
 
     matchingHistories
       .slice(0, MAXIMUM_AUTO_COMPLETIONS)

--- a/src/controllers/keywords.controller.js
+++ b/src/controllers/keywords.controller.js
@@ -6,7 +6,8 @@ exports.searchVideos = async function (req, res, next) {
   const userQuery = userInput.join(" ");
 
   if (!userQuery) {
-    return res.status(200).send({ result: "ok", videos: [], query: userQuery });
+    res.status(200).send({ result: "ok", videos: [], query: userQuery });
+    return;
   }
 
   try {

--- a/src/controllers/keywords.controller.js
+++ b/src/controllers/keywords.controller.js
@@ -5,6 +5,10 @@ exports.searchVideos = async function (req, res, next) {
   const { userInput } = req.body;
   const userQuery = userInput.join(" ");
 
+  if (!userQuery) {
+    return res.status(200).send({ result: "ok", videos: [], query: userQuery });
+  }
+
   try {
     const ranks = await fetchVideosRanks(userQuery);
     const query = await Query.findOne({ text: userQuery });

--- a/src/controllers/videos.controller.js
+++ b/src/controllers/videos.controller.js
@@ -4,7 +4,7 @@ exports.fetchVideo = async function (req, res, next) {
   const youtubeVideoId = req.params.video_id;
 
   try {
-    const video = await Video.findOne({ youtubeVideoId });
+    const video = await Video.findOne({ youtubeVideoId }).lean();
 
     res.status(200).send({ result: "ok", video });
   } catch (error) {

--- a/src/crawler/crawl.js
+++ b/src/crawler/crawl.js
@@ -77,7 +77,7 @@ async function crawl(url) {
   const linksPromises = links.map(async (link) => {
     const videoData = await Video.findOne({
       youtubeVideoId: link.split("=")[1],
-    });
+    }).lean();
 
     if (!videoData) {
       linksQueue.push(link);

--- a/src/crawler/insertIntoDB.js
+++ b/src/crawler/insertIntoDB.js
@@ -8,7 +8,7 @@ const stemWord = require("../utils/stemWord");
 const { K1, B } = require("../constants/crawlerConstants");
 
 async function saveAverageDocumentLength(video) {
-  const totalVideos = await Video.estimatedDocumentCount();
+  const totalVideos = await Video.estimatedDocumentCount().lean();
   const averageDocumentLength = await DocumentData.findOne({
     name: "averageDocumentLength",
   });
@@ -30,7 +30,9 @@ async function saveAverageDocumentLength(video) {
 
 async function saveOriginalKeywords(video, tokens) {
   const originalKeywordsPromises = tokens.map(async (token) => {
-    const originalKeyword = await OriginalKeyword.findOne({ text: token });
+    const originalKeyword = await OriginalKeyword.findOne({
+      text: token,
+    }).lean();
 
     if (!originalKeyword) {
       await OriginalKeyword.create({
@@ -43,10 +45,10 @@ async function saveOriginalKeywords(video, tokens) {
 }
 
 async function saveKeywords(video, words, originalWords) {
-  const totalVideos = await Video.estimatedDocumentCount();
+  const totalVideos = await Video.estimatedDocumentCount().lean();
   const averageDocumentLength = await DocumentData.findOne({
     name: "averageDocumentLength",
-  });
+  }).lean();
   const keywordsPromises = words.map(async (word) => {
     const keyword = await Keyword.findOne({ text: word });
 

--- a/src/utils/fetchVideosRanks.js
+++ b/src/utils/fetchVideosRanks.js
@@ -10,14 +10,14 @@ async function fetchVideosRanks(query) {
   const keywords = [...new Set(tokens.map((token) => stemWord(token)))];
 
   const firstKeyword = keywords.shift();
-  const firstKeywordData = await Keyword.findOne({ text: firstKeyword });
+  const firstKeywordData = await Keyword.findOne({ text: firstKeyword }).lean();
 
   firstKeywordData.videos.forEach((video) => {
     results[video.youtubeVideoId] = parseFloat(video.score);
   });
 
   const keywordsPromises = keywords.map(async (keyword) => {
-    const keywordData = await Keyword.findOne({ text: keyword });
+    const keywordData = await Keyword.findOne({ text: keyword }).lean();
 
     keywordData.videos.forEach((video) => {
       if (results[video.youtubeVideoId]) {


### PR DESCRIPTION
### [[BE] 검색 성능 개선](https://www.notion.so/seongjunhong/Kanban-Task-b371ec4af16c4fe59929d5d57d302add?p=fb73493c6c9a46ecb99a209372adc5fe&pm=s)

### description

- 백엔드 mongoose query 요청들 중 다음 사항을 사용하지 않는 쿼리들은 lean() 메소드를 붙여 사이즈를 줄였습니다.
  - Change tracking
  - Casting and validation
  - Getters and setters
  - Virtuals
  - save()
 - searchVideos 컨트롤러에서 userInput이 비어있을 경우 ('') 에러가 발생하는 문제를 해결 하였습니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### etc

- 크롤링 시 검색에 필요한 로직을 미리 수행해놓는 방식으로 전환 뒤 성능이 많이 향상 돼서, 로직 혹은 db 접근 관련해서 성능 개선점을 찾을 수 있는지 보고 있습니다. 우선 다른 작업 이후 추가 개선 하도록 하겠습니다
