### PR TITLE
Feat: implement check spelling util function using Ngrams and soundex algorithm

### DIFF
--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -5,6 +5,10 @@ exports.getAutoCompletions = async function (req, res, next) {
   const { userInput } = req.query;
   const MAXIMUM_AUTO_COMPLETIONS = 5;
 
+  if (!userInput) {
+    return res.status(200).send([]);
+  }
+
   try {
     const matchingHistories = await Query.find(
       { text: { $regex: `^${userInput}`, $options: "i" } },

--- a/src/controllers/autoCompletion.controller.js
+++ b/src/controllers/autoCompletion.controller.js
@@ -6,7 +6,10 @@ exports.getAutoCompletions = async function (req, res, next) {
   const MAXIMUM_AUTO_COMPLETIONS = 5;
 
   if (!userInput) {
-    return res.status(200).send([]);
+    return res.status(200).send({
+      result: "ok",
+      searchHistories: [],
+    });
   }
 
   try {
@@ -21,7 +24,10 @@ exports.getAutoCompletions = async function (req, res, next) {
       .slice(0, MAXIMUM_AUTO_COMPLETIONS)
       .forEach((element) => searchHistories.push(element.text));
 
-    res.status(200).send(searchHistories);
+    res.status(200).send({
+      result: "ok",
+      searchHistories,
+    });
   } catch (error) {
     console.log(error);
     res.status(500).json({

--- a/src/controllers/keywords.controller.js
+++ b/src/controllers/keywords.controller.js
@@ -1,12 +1,15 @@
 const fetchVideosRanks = require("../utils/fetchVideosRanks");
 const Query = require("../models/Query");
+const checkSpelling = require("../utils/checkSpelling");
 
 exports.searchVideos = async function (req, res, next) {
   const { userInput } = req.body;
   const userQuery = userInput.join(" ");
 
+  const correctedInput = await checkSpelling(userQuery);
+
   try {
-    const ranks = await fetchVideosRanks(userQuery);
+    const ranks = await fetchVideosRanks(correctedInput);
     const query = await Query.findOne({ text: userQuery });
 
     if (query) {

--- a/src/crawler/insertIntoDB.js
+++ b/src/crawler/insertIntoDB.js
@@ -28,18 +28,19 @@ async function saveAverageDocumentLength(video) {
   }
 }
 
-async function saveOriginalKeywords(video, tokens) {
-  const originalKeywordsPromises = tokens.map(async (token) => {
-    const originalKeyword = await OriginalKeyword.findOne({ text: token });
-
-    if (!originalKeyword) {
-      await OriginalKeyword.create({
-        text: token,
-      });
-    }
+async function saveOriginalKeywords(tokens) {
+  const originalKeyword = await OriginalKeyword.findOne({
+    name: "originalKeywords",
   });
 
-  await Promise.allSettled(originalKeywordsPromises);
+  if (originalKeyword) {
+    tokens.forEach((token) => originalKeyword.value.push(token));
+
+    originalKeyword.value = [...new Set(originalKeyword.value)];
+    await originalKeyword.save();
+  } else {
+    await OriginalKeyword.create({ name: "originalKeywords", value: tokens });
+  }
 }
 
 async function saveKeywords(video, words, originalWords) {

--- a/src/models/OriginalKeyword.js
+++ b/src/models/OriginalKeyword.js
@@ -1,8 +1,13 @@
 const mongoose = require("mongoose");
 
 const originalKeywordSchema = new mongoose.Schema({
-  text: {
+  name: {
     type: String,
+    unique: true,
+    required: true,
+  },
+  value: {
+    type: [String],
     unique: true,
   },
 });

--- a/src/utils/checkSpelling.js
+++ b/src/utils/checkSpelling.js
@@ -3,7 +3,8 @@ const OriginalKeyword = require("../models/OriginalKeyword");
 async function getOriginalKeywords() {
   const correctWords = await OriginalKeyword.findOne({
     name: "originalKeywords",
-  });
+  }).lean();
+
   return correctWords.value;
 }
 
@@ -76,10 +77,12 @@ async function checkSpell(misspelledWord) {
     const soundexMatch = misspelledSoundex === correctSoundex;
     const similarityScore = jaccardSimilarity * (soundexMatch ? 1 : 0.5);
 
-    suggestions.push({
-      word: correctWord,
-      similarityScore,
-    });
+    if (similarityScore > 0.5) {
+      suggestions.push({
+        word: correctWord,
+        similarityScore,
+      });
+    }
   }
 
   suggestions.sort((a, b) => b.similarityScore - a.similarityScore);
@@ -92,7 +95,7 @@ async function checkUserInputSpelling(userInput) {
     userInput
       .trim()
       .split(" ")
-      .map((element) => checkSpell(element)),
+      .map((word) => checkSpell(word)),
   );
   const output = [];
 
@@ -100,11 +103,7 @@ async function checkUserInputSpelling(userInput) {
     output.push(element?.word);
   });
 
-  if (output.length) {
-    return output.join(" ");
-  } else {
-    return null;
-  }
+  return output.join(" ");
 }
 
 module.exports = checkUserInputSpelling;

--- a/src/utils/checkSpelling.js
+++ b/src/utils/checkSpelling.js
@@ -1,0 +1,110 @@
+const OriginalKeyword = require("../models/OriginalKeyword");
+
+async function getOriginalKeywords() {
+  const correctWords = await OriginalKeyword.findOne({
+    name: "originalKeywords",
+  });
+  return correctWords.value;
+}
+
+function generateNGrams(input, n) {
+  const ngrams = [];
+
+  for (let i = 0; i < input.length - n + 1; i++) {
+    ngrams.push(input.slice(i, i + n));
+  }
+
+  return ngrams;
+}
+
+function soundex(word) {
+  const codes = {
+    b: 1,
+    f: 1,
+    p: 1,
+    v: 1,
+    c: 2,
+    g: 2,
+    j: 2,
+    k: 2,
+    q: 2,
+    s: 2,
+    x: 2,
+    z: 2,
+    d: 3,
+    t: 3,
+    l: 4,
+    m: 5,
+    n: 5,
+    r: 6,
+  };
+
+  const firstLetter = word.charAt(0).toLowerCase();
+  let soundexCode = firstLetter.toUpperCase();
+
+  let prevCode = codes[firstLetter];
+
+  for (let i = 1; i < word.length; i++) {
+    const letter = word.charAt(i).toLowerCase();
+    const code = codes[letter];
+
+    if (code && code !== prevCode) {
+      soundexCode += code;
+    }
+
+    prevCode = code;
+  }
+
+  return soundexCode.padEnd(4, "0").slice(0, 4);
+}
+
+async function checkSpell(misspelledWord) {
+  const biGramsOfMisspelledWord = generateNGrams(misspelledWord, 2);
+  const misspelledSoundex = soundex(misspelledWord);
+  const allCorrectWords = await getOriginalKeywords();
+  const suggestions = [];
+
+  for (const correctWord of allCorrectWords) {
+    const biGramsOfCorrectWord = generateNGrams(correctWord, 2);
+    const correctSoundex = soundex(correctWord);
+    const intersection = biGramsOfMisspelledWord.filter((element) =>
+      biGramsOfCorrectWord.includes(element),
+    ).length;
+    const union = new Set([...biGramsOfMisspelledWord, ...biGramsOfCorrectWord])
+      .size;
+    const jaccardSimilarity = intersection / union;
+    const soundexMatch = misspelledSoundex === correctSoundex;
+    const similarityScore = jaccardSimilarity * (soundexMatch ? 1 : 0.5);
+
+    suggestions.push({
+      word: correctWord,
+      similarityScore,
+    });
+  }
+
+  suggestions.sort((a, b) => b.similarityScore - a.similarityScore);
+
+  return suggestions[0];
+}
+
+async function checkUserInputSpelling(userInput) {
+  const suggestions = await Promise.all(
+    userInput
+      .trim()
+      .split(" ")
+      .map((element) => checkSpell(element)),
+  );
+  const output = [];
+
+  suggestions.forEach((element) => {
+    output.push(element?.word);
+  });
+
+  if (output.length) {
+    return output.join(" ");
+  } else {
+    return null;
+  }
+}
+
+module.exports = checkUserInputSpelling;


### PR DESCRIPTION
### [[BE] 스팰링 체크 유틸 함수](https://www.notion.so/seongjunhong/BE-13b01285eb8d447eac7bbe875ba0305e?pvs=4)

### 작업한 내용
1. 스펠링 체크를 위한 `NGrams`와 `soundex` 알고리즘을 구현해 보았습니다.
2. `NGrams`와 `soundex`값을 기준으로 자카드 유사도 지수 (`Jaccard Similarity`)를 계산하고, 해당 값에 따라 후보 단어를 추천하는 `checkSpell` 함수를 구현하였습니다.
3. 기존 `OriginalKeyword` 모델 스키마로 테스트 하였을 때 스펠링 검사 시간이 오래 걸리는 점이 확인되어 스키마를 수정하였습니다.
4. 정확도 향상을 위해 다른 알고리즘을 구현하여 테스트 중입니다. (`Levenshtein Distance` 알고리즘)
5. 현재는 유튜브 자막을 기준으로 (자막의 모든 단어는 올바른 단어라는 가정 하에) 스펠링 체크를 하고 있는데, 좀 더 좋은 방법이 있는지 고민중입니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.