### PR TITLE
Feat: combine pagerank algorithm on ranking

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,5 +27,6 @@ module.exports = {
     "func-names": "off",
     "no-unused-vars": "warn",
     "no-param-reassign": 0,
+    "no-await-in-loop": 0,
   },
 };

--- a/src/constants/rankingConstants.js
+++ b/src/constants/rankingConstants.js
@@ -5,6 +5,9 @@ const DESCRIPTION_WEIGHT = 0.3;
 const TRANSCRIPT_WEIGHT = 0.2;
 const TAG_WEIGHT = 0.1;
 
+const DAMPING_FACTOR = 0.85;
+const ITERATIONS = 10;
+
 module.exports = {
   K1,
   B,
@@ -12,4 +15,6 @@ module.exports = {
   DESCRIPTION_WEIGHT,
   TRANSCRIPT_WEIGHT,
   TAG_WEIGHT,
+  DAMPING_FACTOR,
+  ITERATIONS,
 };

--- a/src/controllers/crawling.controller.js
+++ b/src/controllers/crawling.controller.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 const { crawl } = require("../crawler/crawl");
+const { pageRanking } = require("../crawler/pageRanking");
 
 let clients = [];
 let linksQueue = [];
@@ -50,6 +51,8 @@ exports.startCrawling = async function (req, res, next) {
         client.res.write(`data: ${JSON.stringify(newVideoObject)}\n\n`);
       });
     }
+
+    await pageRanking();
 
     res.status(200).send({ result: "ok", message: "crawling finish" });
   } catch (error) {

--- a/src/controllers/crawling.controller.js
+++ b/src/controllers/crawling.controller.js
@@ -1,6 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 const { crawl } = require("../crawler/crawl");
-const { pageRanking } = require("../crawler/pageRanking");
+const { setPageRank } = require("../crawler/setPageRank");
 const { rank } = require("../crawler/rank");
 
 let clients = [];
@@ -71,7 +71,7 @@ exports.startCrawling = async function (req, res, next) {
       );
     });
 
-    await pageRanking();
+    await setPageRank();
     await rank();
 
     res.status(200).send({ result: "ok", message: "crawling finish" });

--- a/src/controllers/crawling.controller.js
+++ b/src/controllers/crawling.controller.js
@@ -1,6 +1,7 @@
 const { v4: uuidv4 } = require("uuid");
 const { crawl } = require("../crawler/crawl");
 const { pageRanking } = require("../crawler/pageRanking");
+const { rank } = require("../crawler/rank");
 
 let clients = [];
 let linksQueue = [];
@@ -42,17 +43,36 @@ exports.startCrawling = async function (req, res, next) {
     linksQueue = [];
 
     while (!shouldStopCrawling) {
-      crawlURL = linksQueue.length === 0 ? entryURL : linksQueue.shift();
+      try {
+        crawlURL = linksQueue.length === 0 ? entryURL : linksQueue.shift();
 
-      const { newVideoObject, newLinksQueue } = await crawl(crawlURL);
-      linksQueue = linksQueue.concat(newLinksQueue);
+        const { newVideoObject, newLinksQueue } = await crawl(crawlURL);
+        linksQueue = linksQueue.concat(newLinksQueue);
 
-      clients.forEach((client) => {
-        client.res.write(`data: ${JSON.stringify(newVideoObject)}\n\n`);
-      });
+        clients.forEach((client) => {
+          client.res.write(
+            `data: ${JSON.stringify({ result: "ok", message: "succeed", title: newVideoObject.title, url: newVideoObject.youtubeVideoId })}\n\n`,
+          );
+        });
+      } catch (error) {
+        console.log(error);
+
+        clients.forEach((client) => {
+          client.res.write(
+            `data: ${JSON.stringify({ result: "ng", message: "fail" })}\n\n`,
+          );
+        });
+      }
     }
 
+    clients.forEach((client) => {
+      client.res.write(
+        `data: ${JSON.stringify({ result: "ok", message: "ranking videos", title: "db" })}\n\n`,
+      );
+    });
+
     await pageRanking();
+    await rank();
 
     res.status(200).send({ result: "ok", message: "crawling finish" });
   } catch (error) {

--- a/src/crawler/crawl.js
+++ b/src/crawler/crawl.js
@@ -65,12 +65,12 @@ async function crawl(url) {
   }
 
   const links = await page.$$eval(LINKS_SELECTOR, (elements) => {
-    return Array.from(elements)
-      .map((element) => element.href)
-      .slice(0, 5);
+    return Array.from(elements).map((element) => element.href);
   });
 
-  const linksPromises = links.map(async (link) => {
+  const allForwardLinks = [];
+
+  const linksPromises = links.slice(0, 5).map(async (link) => {
     const videoData = await Video.findOne({
       youtubeVideoId: link.split("=")[1],
     }).lean();
@@ -81,6 +81,12 @@ async function crawl(url) {
   });
 
   await Promise.all(linksPromises);
+
+  links.forEach((link) => {
+    allForwardLinks.push(link.split("=")[1]);
+  });
+
+  newVideoObject.allForwardLinks = allForwardLinks;
 
   try {
     newVideoObject.title = await page.$eval(

--- a/src/crawler/insertIntoDB.js
+++ b/src/crawler/insertIntoDB.js
@@ -107,8 +107,8 @@ async function saveKeywords(video, words, originalWords, fieldTokens, session) {
     const TFs = {
       titleTF: calculateTF(fieldTokens.titleTokens, word),
       descriptionTF: calculateTF(fieldTokens.descriptionTokens, word),
-      transcriptTF: calculateTF(fieldTokens.descriptionTokens, word),
-      tagTermTF: calculateTF(fieldTokens.transcriptTokens, word),
+      transcriptTF: calculateTF(fieldTokens.transcriptTokens, word),
+      tagTF: calculateTF(fieldTokens.tagTokens, word),
     };
 
     if (keyword) {

--- a/src/crawler/pageRanking.js
+++ b/src/crawler/pageRanking.js
@@ -1,0 +1,112 @@
+const { DAMPING_FACTOR, ITERATIONS } = require("../constants/rankingConstants");
+
+const Video = require("../models/Video");
+
+async function setBackLinks() {
+  try {
+    const videos = await Video.find();
+
+    const videosPromises = videos.map(async (video) => {
+      const forwardLinks = [];
+
+      await Promise.all(
+        video.allForwardLinks.map(async (forwardLink) => {
+          const forwardVideo = await Video.findOne({
+            youtubeVideoId: forwardLink,
+          });
+
+          if (
+            forwardVideo &&
+            forwardVideo.youtubeVideoId !== video.youtubeVideoId &&
+            !forwardVideo.backLinks.includes(video.youtubeVideoId)
+          ) {
+            forwardVideo.backLinks.push(video.youtubeVideoId);
+
+            await forwardVideo.save();
+          }
+
+          if (
+            forwardVideo &&
+            forwardVideo.youtubeVideoId !== video.youtubeVideoId
+          ) {
+            forwardLinks.push(forwardLink);
+          }
+        }),
+      );
+
+      await Video.findOneAndUpdate(
+        { youtubeVideoId: video.youtubeVideoId },
+        { forwardLinks },
+      );
+    });
+
+    await Promise.all(videosPromises);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function calculatePageRank(dampingFactor, iterations) {
+  try {
+    const pageRank = {};
+    const videos = await Video.find().lean();
+    const totalVideos = await Video.estimatedDocumentCount().lean();
+
+    videos.forEach((video) => {
+      pageRank[video.youtubeVideoId] = 1 / totalVideos;
+    });
+
+    for (let i = 0; i < iterations; i += 1) {
+      await Promise.allSettled(
+        videos.map(async (video) => {
+          let newRank = 0;
+          const targetYoutubeVideoId = video.youtubeVideoId;
+
+          const newRankPromises = video.backLinks.map(
+            async (youtubeVideoId) => {
+              const targetVideo = await Video.findOne({
+                youtubeVideoId,
+              }).lean();
+
+              newRank +=
+                pageRank[youtubeVideoId] /
+                (targetVideo.forwardLinks.length || totalVideos);
+            },
+          );
+
+          await Promise.all(newRankPromises);
+
+          newRank = (1 - dampingFactor) / totalVideos + dampingFactor * newRank;
+
+          pageRank[targetYoutubeVideoId] = newRank;
+        }),
+      );
+    }
+
+    await Promise.all(
+      Object.keys(pageRank).map(async (youtubeVideoId) => {
+        const video = await Video.findOne({ youtubeVideoId });
+
+        video.pageRankScore = pageRank[youtubeVideoId];
+
+        await video.save();
+      }),
+    );
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function pageRanking() {
+  console.log("Start calculating page rank");
+
+  try {
+    await setBackLinks();
+    await calculatePageRank(DAMPING_FACTOR, ITERATIONS);
+    console.log("Finish calculating page rank");
+  } catch (error) {
+    console.error(error.message);
+  }
+}
+
+module.exports = { pageRanking };

--- a/src/crawler/rank.js
+++ b/src/crawler/rank.js
@@ -1,0 +1,28 @@
+const Keyword = require("../models/Keyword");
+
+async function rank() {
+  console.log("Start Ranking for all keywords");
+
+  const keywords = await Keyword.find().populate("videos.videoId");
+
+  try {
+    await Promise.all(
+      keywords.map(async (keyword) => {
+        keyword.videos.forEach((video) => {
+          video.score *= parseFloat(video.videoId.pageRankScore, 10);
+        });
+
+        keyword.videos = keyword.videos.sort(
+          (videoOne, videoTwo) => videoTwo.score - videoOne.score,
+        );
+
+        await keyword.save();
+      }),
+    );
+  } catch (error) {
+    console.error(error);
+  }
+  console.log("Finish Ranking for all keywords");
+}
+
+module.exports = { rank };

--- a/src/crawler/setPageRank.js
+++ b/src/crawler/setPageRank.js
@@ -2,7 +2,7 @@ const { DAMPING_FACTOR, ITERATIONS } = require("../constants/rankingConstants");
 
 const Video = require("../models/Video");
 
-async function setBackLinks() {
+async function setBackwardLinks() {
   try {
     const videos = await Video.find();
 
@@ -18,9 +18,9 @@ async function setBackLinks() {
           if (
             forwardVideo &&
             forwardVideo.youtubeVideoId !== video.youtubeVideoId &&
-            !forwardVideo.backLinks.includes(video.youtubeVideoId)
+            !forwardVideo.backwardLinks.includes(video.youtubeVideoId)
           ) {
-            forwardVideo.backLinks.push(video.youtubeVideoId);
+            forwardVideo.backwardLinks.push(video.youtubeVideoId);
 
             await forwardVideo.save();
           }
@@ -57,12 +57,12 @@ async function calculatePageRank(dampingFactor, iterations) {
     });
 
     for (let i = 0; i < iterations; i += 1) {
-      await Promise.allSettled(
+      await Promise.all(
         videos.map(async (video) => {
           let newRank = 0;
           const targetYoutubeVideoId = video.youtubeVideoId;
 
-          const newRankPromises = video.backLinks.map(
+          const newRankPromises = video.backwardLinks.map(
             async (youtubeVideoId) => {
               const targetVideo = await Video.findOne({
                 youtubeVideoId,
@@ -97,11 +97,11 @@ async function calculatePageRank(dampingFactor, iterations) {
   }
 }
 
-async function pageRanking() {
+async function setPageRank() {
   console.log("Start calculating page rank");
 
   try {
-    await setBackLinks();
+    await setBackwardLinks();
     await calculatePageRank(DAMPING_FACTOR, ITERATIONS);
     console.log("Finish calculating page rank");
   } catch (error) {
@@ -109,4 +109,4 @@ async function pageRanking() {
   }
 }
 
-module.exports = { pageRanking };
+module.exports = { setPageRank };

--- a/src/models/Keyword.js
+++ b/src/models/Keyword.js
@@ -21,27 +21,27 @@ const keywordSchema = new mongoose.Schema({
         },
         TF: {
           type: Number,
-          default: 1,
+          default: 0,
           required: true,
         },
         titleTF: {
           type: Number,
-          default: 1,
+          default: 0,
           required: true,
         },
         descriptionTF: {
           type: Number,
-          default: 1,
+          default: 0,
           required: true,
         },
         transcriptTF: {
           type: Number,
-          default: 1,
+          default: 0,
           required: true,
         },
         tagTF: {
           type: Number,
-          default: 1,
+          default: 0,
           required: true,
         },
         score: {

--- a/src/models/Video.js
+++ b/src/models/Video.js
@@ -65,7 +65,7 @@ const videoSchema = new mongoose.Schema({
     default: [],
     required: true,
   },
-  backLinks: {
+  backwardLinks: {
     type: Array,
     default: [],
     required: true,

--- a/src/models/Video.js
+++ b/src/models/Video.js
@@ -60,6 +60,24 @@ const videoSchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
+  forwardLinks: {
+    type: Array,
+    default: [],
+    required: true,
+  },
+  backLinks: {
+    type: Array,
+    default: [],
+    required: true,
+  },
+  allForwardLinks: {
+    type: Array,
+    default: [],
+    required: true,
+  },
+  pageRankScore: {
+    type: mongoose.Decimal128,
+  },
 });
 
 videoSchema.pre("validate", function (next) {


### PR DESCRIPTION
### [[BE] bm25f, pagerank 알고리즘 (검색 고도화)](https://www.notion.so/seongjunhong/BE-bm25f-pagerank-9257832aa093488da37586208a98295e?pvs=4)

### description

- 도큐먼트의 각 필드(titie, description, script)에 대해서 가중치를 다르게 주기
- pagerank 알고리즘을 사용하여 모든 비디오에 대한 점수를 매깁니다.
- bm25f에서 구한 점수와 pagerank에서 구한 점수를 모두 고려하여 새로운 점수를 매기고 정렬합니다.

### PR 전 확인사항

- [x] 가장 최신 브랜치를 pull하기.
- [x] 브랜치명을 확인하기.
- [x] 코드 컨벤션을 모두 지키기.
- [x] PR제목이 브랜치명, task명을 포함하기.
- [x] assignee확인하기.

### etc

- pagerank 값을 계산한 후 모든 키워드의 동영상 점수를 바꿔줘야 하므로 bm25점수도 크롤링과 분리하려고 했으나 마지막에 점수 계산 부분의 시간복잡도가 크게 증가하여 bm25점수는 크롤링과 함께 미리 구해놓는 로직으로 진행하였습니다.
